### PR TITLE
bugfix: the script runs perl with the "-w" option, which confuses /usr/bin/env

### DIFF
--- a/phobius.rb
+++ b/phobius.rb
@@ -9,7 +9,7 @@ class Phobius < Formula
 
   def install 
     cd 'tmpCG3gh3/phobius' do
-      inreplace 'phobius.pl', '/usr/bin/perl', '/usr/bin/env perl'
+      inreplace 'phobius.pl', '/usr/bin/perl -w', "/usr/bin/env perl\nuse warnings;"
       prefix.install Dir['*']
     end
   end


### PR DESCRIPTION
Solves this:
```
ebi-cli-001 $ /nfs/software/ensembl/RHEL7-JUL2017-core2/linuxbrew/Cellar/phobius/1.01/phobius.pl
/usr/bin/env: perl -w: No such file or directory
```
and my test runs of interproscan (which wants to run phobius)
